### PR TITLE
Corrected(rx-buffer-increase): check that config for iface exists

### DIFF
--- a/utils/rx-buffers-increase
+++ b/utils/rx-buffers-increase
@@ -38,7 +38,10 @@ class RxBuffersIncreaser(object):
     def investigate(self):
         """ get maximum and current rx ring buffers values via ethtool """
         ns = '/etc/sysconfig/network-scripts/'
-        with open(path.join(ns, 'ifcfg-' + self.dev)) as config:
+        iface_cfg = path.join(ns, 'ifcfg-' + self.dev)
+        if not path.exists(iface_cfg):
+            return 0
+        with open(iface_cfg) as config:
             if any(line for line in config.xreadlines() if 'ETHTOOL_OPTS' in line):
                 print "{0}'s RX ring buffer already manually tuned.".format(self.dev)
                 exit(0)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/rx-buffers-increase", line 124, in <module>
    main()
  File "/usr/bin/rx-buffers-increase", line 117, in main
    RxBuffersIncreaser(dev, upper_bound).apply()
  File "/usr/bin/rx-buffers-increase", line 74, in apply
    self.investigate()
  File "/usr/bin/rx-buffers-increase", line 41, in investigate
    with open(path.join(ns, 'ifcfg-' + self.dev)) as config:
IOError: [Errno 2] No such file or directory: '/etc/sysconfig/network-scripts/ifcfg-eth2'