### PR TITLE
Refactoring: make_parser() split

### DIFF
--- a/netutils_linux_monitoring/base_top.py
+++ b/netutils_linux_monitoring/base_top.py
@@ -1,5 +1,6 @@
-from abc import abstractmethod
+# coding: utf-8
 import argparse
+from abc import abstractmethod
 from os import system
 from random import randint
 from time import sleep
@@ -17,9 +18,11 @@ class BaseTop(object):
     diff = None
     header = wrap("Press CTRL-C to exit...\n", Fore.LIGHTBLACK_EX)
     options = None
+    file_arg = None
+    file_value = None
 
     @staticmethod
-    def make_parser(parser=None):
+    def make_base_parser(parser=None):
         """ That should be explicitly called in __main__ part of any top-like utils """
         if not parser:
             parser = argparse.ArgumentParser()
@@ -46,6 +49,14 @@ class BaseTop(object):
         parser.add_argument('--no-clear', default=True, dest='clear', action='store_false',
                             help="Don't clear screen after each iteration. "
                                  "May be useful in scripts/logging to file.")
+        return parser
+
+    def make_parser(self, parser=None):
+        if type(self) == BaseTop:
+            raise TypeError("make_parser should not be called directly by BaseTop")
+        if not parser:
+            parser = BaseTop.make_base_parser()
+        parser.add_argument(self.file_arg, default=self.file_value, help='Option for testing on MacOS purpose.')
         return parser
 
     def tick(self):

--- a/netutils_linux_monitoring/irqtop.py
+++ b/netutils_linux_monitoring/irqtop.py
@@ -14,18 +14,11 @@ from netutils_linux_monitoring.topology import Topology
 class IrqTop(BaseTop):
     """ Utility for monitoring hardware interrupts distribution """
     diff_total = None
+    file_arg, file_value = '--interrupts-file', '/proc/interrupts'
 
     def __init__(self, topology=None):
         BaseTop.__init__(self)
         self.topology = topology
-
-    @staticmethod
-    def make_parser(parser=None):
-        if not parser:
-            parser = BaseTop.make_parser()
-        parser.add_argument('--interrupts-file', default='/proc/interrupts',
-                            help='Option for testing on MacOS purpose.')
-        return parser
 
     def post_optparse(self):
         if not self.topology:

--- a/netutils_linux_monitoring/link_rate.py
+++ b/netutils_linux_monitoring/link_rate.py
@@ -38,10 +38,9 @@ class LinkRateTop(BaseTop):
         BaseTop.__init__(self)
         self.pci = pci
 
-    @staticmethod
-    def make_parser(parser=None):
+    def make_parser(self, parser=None):
         if not parser:
-            parser = BaseTop.make_parser()
+            parser = BaseTop.make_base_parser()
         parser.add_argument('--assert', '--assert-mode', default=False, dest='assert_mode',
                             help='Stops running after errors detected.')
         parser.add_argument('--dev', '--devices', default="", dest='devices',

--- a/netutils_linux_monitoring/network_top.py
+++ b/netutils_linux_monitoring/network_top.py
@@ -57,7 +57,7 @@ class NetworkTop(BaseTop):
 
     def parse_options(self):
         """ Tricky way to gather all options in one util without conflicts, parse them and do some logic after parse """
-        parser = BaseTop.make_parser()
+        parser = BaseTop.make_base_parser()
         for top in itervalues(self.tops):
             parser = top.make_parser(parser)
         self.options = parser.parse_args()

--- a/netutils_linux_monitoring/snmptop.py
+++ b/netutils_linux_monitoring/snmptop.py
@@ -11,17 +11,8 @@ from netutils_linux_monitoring.layout import make_table
 
 class SnmpTop(BaseTop):
     """ Utility for monitoring IP/TCP/UDP/ICMP parts of network stack based on /proc/net/snmp values """
-
     protos = ['IP', 'TCP', 'UDP', 'ICMP']
-
-    @staticmethod
-    def make_parser(parser=None):
-        """ :returns: parser with options for snmptop """
-        if not parser:
-            parser = BaseTop.make_parser()
-        parser.add_argument('--snmp-file', default='/proc/net/snmp',
-                            help='Option for testing on MacOS purpose.')
-        return parser
+    file_arg, file_value = '--snmp-file', '/proc/net/snmp'
 
     def __int(self, line):
         return [self.int(item) for item in line.strip().split()]

--- a/netutils_linux_monitoring/softirqs.py
+++ b/netutils_linux_monitoring/softirqs.py
@@ -8,18 +8,11 @@ from netutils_linux_monitoring.topology import Topology
 
 class Softirqs(BaseTop):
     """ Utility for monitoring software interrupts distribution """
+    file_arg, file_value = '--softirqs-file', '/proc/softirqs'
 
     def __init__(self, topology=None):
         BaseTop.__init__(self)
         self.topology = topology
-
-    @staticmethod
-    def make_parser(parser=None):
-        if not parser:
-            parser = BaseTop.make_parser()
-        parser.add_argument('--softirqs-file', default='/proc/softirqs',
-                            help='Option for testing on MacOS purpose.')
-        return parser
 
     def post_optparse(self):
         if not self.topology:

--- a/netutils_linux_monitoring/softnet_stat.py
+++ b/netutils_linux_monitoring/softnet_stat.py
@@ -53,7 +53,7 @@ class SoftnetStat(object):
 
 class SoftnetStatTop(BaseTop):
     """ Utility for monitoring packets processing/errors distribution per CPU """
-
+    file_arg, file_value = '--softnet-stat-file', '/proc/net/softnet_stat'
     align = ['l'] + ['r'] * 5
     total_warning, total_error = 300000, 900000
     dropped_warning = dropped_error = 1
@@ -63,14 +63,6 @@ class SoftnetStatTop(BaseTop):
     def __init__(self, topology=None):
         BaseTop.__init__(self)
         self.topology = topology
-
-    @staticmethod
-    def make_parser(parser=None):
-        if not parser:
-            parser = BaseTop.make_parser()
-        parser.add_argument('--softnet-stat-file', default='/proc/net/softnet_stat',
-                            help='Option for testing on MacOS purpose.')
-        return parser
 
     def post_optparse(self):
         if not self.topology:


### PR DESCRIPTION
Results are make_base_parser() and make_parser().

Irqtop, snmptop, softirq-top, softnet-stat-top are has no directly defined make_parser().
Everything is done by BaseTop (they inherit it).
Utils are just required to define 2 const variables - file_arg (arg_name) and file_value (default_value).