### PR TITLE
fix: incompatibilities with modern systems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Utils
 Monitoring
 ----------
 
-All these top-like utils don't require root priveledges or sudo usage. So you can install and use them as non-priveledged user if you care about security.
+All these top-like utils don't require root privileges or sudo usage. So you can install and use them as non-privileged user if you care about security.
 
 .. code:: shell
 
@@ -96,7 +96,7 @@ It also supports double/quad ladder in case of multiprocessor systems (but you b
 
 autorps
 ~~~~~~~
-Enables RPS on all available CPUs of NUMA node local for the NIC for all NIC's rx queues. It may be good for small servers with cheap network cards. You also can explicitely pass ``--cpus`` or ``--cpu-mask``. Example output:
+Enables RPS on all available CPUs of NUMA node local for the NIC for all NIC's rx queues. It may be good for small servers with cheap network cards. You can also explicitly pass ``--cpus`` or ``--cpu-mask``. Example output:
 
 .. code::
 

--- a/netutils_linux_hardware/cpu.py
+++ b/netutils_linux_hardware/cpu.py
@@ -30,7 +30,7 @@ class CPU(Subsystem):
         }
         for key in ('CPU MHz', 'BogoMIPS'):
             if output.get('info', {}).get(key):
-                output['info'][key] = int(output['info'][key])
+                output['info'][key] = int(float(output['info'][key]))
         return output
 
 

--- a/netutils_linux_hardware/net.py
+++ b/netutils_linux_hardware/net.py
@@ -105,7 +105,7 @@ class EthtoolBuffers(Parser):
     def parse(text):
         buffers = [int(line.split()[1])
                    for line in text.strip().split('\n')
-                   if line.startswith('RX:')]
+                   if line.startswith('RX:') and line.split()[1].isdigit()]
         if buffers and len(buffers) == 2:
             return {
                 'max': buffers[0],

--- a/netutils_linux_monitoring/base_top.py
+++ b/netutils_linux_monitoring/base_top.py
@@ -112,8 +112,6 @@ class BaseTop(object):
         return (str(number % 1000) + sep + output).strip()
 
     def __repr_table__(self, table):
-        if self.options.clear:
-            return self.header + str(table)
         return str(table)
 
     def default_init(self, topology=None):

--- a/netutils_linux_monitoring/network_top.py
+++ b/netutils_linux_monitoring/network_top.py
@@ -113,7 +113,6 @@ class NetworkTop(BaseTop):
                 irqtop.colorize_irq_per_cpu(irq),
                 softirq_top.colorize_net_rx(net_rx),
                 softirq_top.colorize_net_tx(net_tx),
-                # Теперь я вспомнил зачем там были семантичные функции, чтобы не было дублирования
                 self.color.colorize(stat.total, 300000, 900000),
                 self.color.colorize(stat.dropped, 1, 1),
                 self.color.colorize(stat.time_squeeze, 1, 300),

--- a/netutils_linux_monitoring/topology.py
+++ b/netutils_linux_monitoring/topology.py
@@ -51,11 +51,6 @@ class Topology(object):
         if return_code != 0:
             self.detect_layouts_fallback()
             return
-        if isinstance(stdout, bytes):
-            if version_info[0] == 3:
-                stdout = stdout.decode()
-            else:
-                stdout = str(stdout)
         return stdout
 
     def detect_layouts_fallback(self):
@@ -64,6 +59,11 @@ class Topology(object):
         """
         process = Popen(['nproc'], stdout=PIPE, stderr=PIPE)
         stdout, _ = process.communicate()
+        if isinstance(stdout, bytes):
+            if version_info[0] == 3:
+                stdout = stdout.decode()
+            else:
+                stdout = str(stdout)
         if process.returncode == 0:
             cpu_count = int(stdout.strip())
             self.socket_layout = self.numa_layout = dict(enumerate([0] * cpu_count))
@@ -72,6 +72,11 @@ class Topology(object):
     def __detect_layout_lscpu():
         process = Popen(['lscpu', '-p'], stdout=PIPE, stderr=PIPE)
         stdout, _ = process.communicate()
+        if isinstance(stdout, bytes):
+            if version_info[0] == 3:
+                stdout = stdout.decode()
+            else:
+                stdout = str(stdout)
         return stdout, process.returncode
 
 

--- a/netutils_linux_tuning/rx_buffers.py
+++ b/netutils_linux_tuning/rx_buffers.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-0. Check if buffers already been setted up in ifcfg-ethX
-1. Determines what size of buffers available
-2. Evaluate one that fits for our purposes
+0. Check if buffers have already been set up in ifcfg-ethX
+1. Determine what sizes of buffers are available
+2. Evaluate one that fits our purposes
 3. Apply it
 """
 
@@ -19,7 +19,7 @@ from netutils_linux_tuning.base_tune import BaseTune
 class RxBuffersTune(BaseTune):
     """ Tune utility for RX buffers of NIC """
 
-    prefered = None
+    preferred = None
     current = 0
     maximum = 0
     manual_tuned = False
@@ -32,7 +32,7 @@ class RxBuffersTune(BaseTune):
         self.apply(self.eval())
 
     def __str__(self):
-        attrs = ('dev', 'upper_bound', 'current', 'maximum', 'prefered')
+        attrs = ('dev', 'upper_bound', 'current', 'maximum', 'preferred')
         return str(dict((attr, self.__getattribute__(attr)) for attr in attrs))
 
     def parse(self):
@@ -43,14 +43,14 @@ class RxBuffersTune(BaseTune):
 
     def eval(self):
         """ Just wrapper for static function """
-        return self.eval_prefered_size(self.current, self.maximum, self.options.upper_bound)
+        return self.eval_preferred_size(self.current, self.maximum, self.options.upper_bound)
 
     def apply(self, decision):
         """ doing all the job, applying new buffer's size if required """
         if decision == self.current:
             print_("{0}'s RX ring buffer already has fine size {1}.".format(self.options.dev, self.current))
             return
-        assert decision, "Can't eval prefered RX ring buffer size."
+        assert decision, "Can't eval preferred RX ring buffer size."
         command = 'ethtool -G {0} rx {1}'.format(self.options.dev, decision)
         print_('run:', command)
         if not self.options.dry_run:
@@ -114,9 +114,9 @@ class RxBuffersTune(BaseTune):
         exit(0)
 
     @staticmethod
-    def eval_prefered_size(current, maximum, upper_bound):
+    def eval_preferred_size(current, maximum, upper_bound):
         """
-        :return: really calculates the prefered size of RX buffers
+        :return: really calculates the preferred size of RX buffers
         """
         if current > upper_bound:
             return current

--- a/netutils_linux_tuning/rx_buffers.py
+++ b/netutils_linux_tuning/rx_buffers.py
@@ -75,7 +75,7 @@ class RxBuffersTune(BaseTune):
         stdout, _ = process.communicate()
         if process.returncode != 0:
             exit(exit_code)
-        return stdout
+        return str(stdout, 'UTF-8')
 
     def parse_ethtool_buffers(self):
         """

--- a/netutils_linux_tuning/rx_buffers.py
+++ b/netutils_linux_tuning/rx_buffers.py
@@ -9,6 +9,7 @@
 
 from os import system, path
 from subprocess import Popen, PIPE
+from sys import version_info
 
 from six import print_
 
@@ -73,9 +74,14 @@ class RxBuffersTune(BaseTune):
         """
         process = Popen(['ethtool', key, self.options.dev], stdout=PIPE, stderr=PIPE)
         stdout, _ = process.communicate()
+        if isinstance(stdout, bytes):
+            if version_info[0] == 3:
+                stdout = stdout.decode()
+            else:
+                stdout = str(stdout)
         if process.returncode != 0:
             exit(exit_code)
-        return str(stdout, 'UTF-8')
+        return stdout
 
     def parse_ethtool_buffers(self):
         """

--- a/netutils_linux_tuning/test_rx_buffers.py
+++ b/netutils_linux_tuning/test_rx_buffers.py
@@ -22,7 +22,7 @@ class RxBuffersTuneTest(unittest.TestCase):
     def test_all(self):
         for max_buffer in self.dataset:
             for current, expected in self.dataset[max_buffer]:
-                self.assertEqual(self.tune.eval_prefered_size(current, max_buffer, self.default_upper_bound), expected)
+                self.assertEqual(self.tune.eval_preferred_size(current, max_buffer, self.default_upper_bound), expected)
 
 
 if __name__ == '__main__':

--- a/utils/server-info-collect
+++ b/utils/server-info-collect
@@ -20,7 +20,7 @@ server_info() {
 		echo "Consider install lspci" >&2
 		echo "	yum -y install pciutils" >&2
 	fi
-	LANG= lscpu > $TMPDIR/lscpu_info
+	LANG= lscpu | awk -F: '{gsub(/[[:blank:]]+/, " ", $0); print $0}' | awk -F': ' '{print $1 ": \"" $2 "\""}' > $TMPDIR/lscpu_info
 	LANG= lscpu -p | grep -v '^#' | awk -F ',' '{print $1" "$3}' > $TMPDIR/lscpu_layout
 	if ! LANG= dmidecode --type memory 2>/dev/null > $TMPDIR/dmidecode; then
 		echo "Consider installing dmidecode:" >&2


### PR DESCRIPTION
Fixed as many issues as I could find on a modern Debian 11 distro:

- lscpu output may contain ":" characters in values breaking yaml parser, e.g.:
```Vulnerability Mmio stale data:   Vulnerable: Clear CPU buffers attempted, no mic  rocode; SMT vulnerable```
- "RX:" entries may contain "n/a" (string values) breaking casting to int
- process.communicate() returns bytearray (at least in Python 3.9)
- `__repr_table__` in the `link-rate` tried to concat list with str producing an error. 